### PR TITLE
매니저 마감 수정: 자유적금 단리/복리 이자 계산

### DIFF
--- a/src/main/java/com/kcc/banking/domain/account/dto/response/AccountDetailForInterest.java
+++ b/src/main/java/com/kcc/banking/domain/account/dto/response/AccountDetailForInterest.java
@@ -18,9 +18,18 @@ public class AccountDetailForInterest {
     private BigDecimal preferentialInterestRate;
     private BigDecimal balance;
 
+    // 예금 적금 유형 구분
+    private String period;
+    // 자율적립/정기적립 유형 구분
+    //
+    private String productType;
+    // 상품 이자 계산 방법
+    private String interestCalculationMethod;
+
+
 
     @Builder
-    public AccountDetailForInterest(String accId, Long branchId, Long productId, Long registrantId, BigDecimal interestRate, BigDecimal preferentialInterestRate, BigDecimal balance) {
+    public AccountDetailForInterest(String accId, Long branchId, Long productId, Long registrantId, BigDecimal interestRate, BigDecimal preferentialInterestRate, BigDecimal balance, String period, String productType, String interestCalculationMethod) {
         this.accId = accId;
         this.branchId = branchId;
         this.productId = productId;
@@ -28,5 +37,8 @@ public class AccountDetailForInterest {
         this.interestRate = interestRate;
         this.preferentialInterestRate = preferentialInterestRate;
         this.balance = balance;
+        this.period = period;
+        this.productType = productType;
+        this.interestCalculationMethod = interestCalculationMethod;
     }
 }

--- a/src/main/java/com/kcc/banking/domain/business_day/service/BusinessDayManagementFacade.java
+++ b/src/main/java/com/kcc/banking/domain/business_day/service/BusinessDayManagementFacade.java
@@ -140,14 +140,12 @@ public class BusinessDayManagementFacade {
             throw new BadRequestException(ErrorCode.ALREADY_CLOSED_BUSINESS_DAY);
 
         // 3
-
         businessDayCloseService.closeBranchBusinessDay(businessDateAndBranchId, vaultCashRequest);
 
         // 4
-
         businessDayService.businessDayStatusToClosed(currentBusinessDate);
 
-        // 5
+        // 5 - 보통예금, 자율적금 단복리 이자 내역 추가
         String tradeNumber = businessDayCloseService.getClosingTradeNumber(businessDateAndBranchId);
         interestService.createInterest(tradeNumber, businessDateAndBranchId);
     }

--- a/src/main/java/com/kcc/banking/domain/interest/dto/request/SavingInterestCreate.java
+++ b/src/main/java/com/kcc/banking/domain/interest/dto/request/SavingInterestCreate.java
@@ -1,0 +1,60 @@
+package com.kcc.banking.domain.interest.dto.request;
+
+import com.kcc.banking.domain.account.dto.response.AccountDetailForInterest;
+import com.kcc.banking.domain.employee.dto.request.BusinessDateAndBranchId;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@NoArgsConstructor
+@Setter
+@Getter
+public class SavingInterestCreate {
+    private Long id; // sequence
+    private String accId; // 대상계좌
+    private BigDecimal amount; // 금액
+    private BigDecimal interestRate; // 기본이율
+    private BigDecimal preferentialInterestRate; // 우대이율
+    private String paymentStatus; // 지금상태
+    private String tradeNumber; // 생성 거래 번호
+    private String branchId; // 생성 지점
+    private Long registrantId; // 생성한 사람
+    private String creationDate; // 생성일
+    private Long version;
+
+    @Builder
+    public SavingInterestCreate(Long id, String accId, BigDecimal amount, BigDecimal interestRate, BigDecimal preferentialInterestRate, String paymentStatus, String tradeNumber, String branchId, Long registrantId, String creationDate, Long version) {
+        this.id = id;
+        this.accId = accId;
+        this.amount = amount;
+        this.interestRate = interestRate;
+        this.preferentialInterestRate = preferentialInterestRate;
+        this.paymentStatus = paymentStatus;
+        this.tradeNumber = tradeNumber;
+        this.branchId = branchId;
+        this.registrantId = registrantId;
+        this.creationDate = creationDate;
+        this.version = version;
+    }
+
+
+    /**
+     * @Discription
+     * 1. 잔액에 대한 월별 이자 계산
+     * 2. 단리 / 복리 계산 분기처리
+     * 3. 지급 상태는 모두 N
+     * 4. branchId와 registrantId는 마감 진행자인 매니저 ID
+     *
+     * @param accountDetail
+     * @param loginMemberId
+     * @param businessDateAndBranchId
+     * @param tradeNumber
+     * @return
+     */
+    public static SavingInterestCreate of (AccountDetailForInterest accountDetail, Long loginMemberId, BusinessDateAndBranchId businessDateAndBranchId, String tradeNumber){
+        return null;
+    }
+}

--- a/src/main/java/com/kcc/banking/domain/interest/dto/request/SavingInterestCreate.java
+++ b/src/main/java/com/kcc/banking/domain/interest/dto/request/SavingInterestCreate.java
@@ -2,12 +2,15 @@ package com.kcc.banking.domain.interest.dto.request;
 
 import com.kcc.banking.domain.account.dto.response.AccountDetailForInterest;
 import com.kcc.banking.domain.employee.dto.request.BusinessDateAndBranchId;
+import com.kcc.banking.domain.interest.dto.response.InterestSum;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
 
 @NoArgsConstructor
 @Setter
@@ -42,19 +45,60 @@ public class SavingInterestCreate {
 
 
     /**
-     * @Discription
-     * 1. 잔액에 대한 월별 이자 계산
-     * 2. 단리 / 복리 계산 분기처리
-     * 3. 지급 상태는 모두 N
-     * 4. branchId와 registrantId는 마감 진행자인 매니저 ID
-     *
      * @param accountDetail
      * @param loginMemberId
      * @param businessDateAndBranchId
      * @param tradeNumber
+     * @param interestSavingSum
      * @return
+     * @Discription 1. 잔액에 대한 월별 이자 계산
+     * 2. 단리 / 복리 계산 분기처리
+     * 3. 지급 상태는 모두 N
+     * 4. branchId와 registrantId는 마감 진행자인 매니저 ID
      */
-    public static SavingInterestCreate of (AccountDetailForInterest accountDetail, Long loginMemberId, BusinessDateAndBranchId businessDateAndBranchId, String tradeNumber){
-        return null;
+    public static SavingInterestCreate of(AccountDetailForInterest accountDetail, Long loginMemberId, BusinessDateAndBranchId businessDateAndBranchId, String tradeNumber, InterestSum interestSavingSum) {
+        // 잔액 및 이자율 합산
+        BigDecimal balance = accountDetail.getBalance();
+        // 이자율을 퍼센트에서 소수로 변환 후 합산 (2.6% -> 0.026)
+        BigDecimal interestRateSum = accountDetail.getInterestRate().add(accountDetail.getPreferentialInterestRate())
+                .divide(BigDecimal.valueOf(100), 8, RoundingMode.DOWN); // scale을 8로 설정
+
+        // 월 이자율 계산 (연 이자율을 12로 나눔, 소수점 자릿수 유지)
+        BigDecimal monthlyInterestRate = interestRateSum.divide(BigDecimal.valueOf(12), 8, RoundingMode.DOWN);
+
+
+        // 이자 계산 (단리 또는 복리)
+        BigDecimal interestAmount = null;
+        if (accountDetail.getInterestCalculationMethod().equals("SIMPLE")) {
+            // 단리 계산
+            interestAmount = balance.multiply(monthlyInterestRate);
+        } else if (accountDetail.getInterestCalculationMethod().equals("COMPOUND")) {
+            // 1. 복리 계산
+            // 1-1. 복리인데 첫 달이라면 단리와 동일하게 원금에 대한 이자 계산
+            if (interestSavingSum == null) {
+                interestAmount = balance.multiply(monthlyInterestRate);
+            }
+            // 1-2. 첫 달이 아니라면 원금과 이자를 합산한 금액에 대한 이자 계산
+            else {
+                BigDecimal balanceWithInterest = balance.add(interestSavingSum.getAmountSum());
+                interestAmount = balanceWithInterest.multiply(monthlyInterestRate);
+            }
+        }
+
+        // SavingInterestCreate 객체 생성
+        return SavingInterestCreate.builder()
+                .accId(accountDetail.getAccId())
+                .amount(interestAmount)
+                .interestRate(accountDetail.getInterestRate())
+                .preferentialInterestRate(accountDetail.getPreferentialInterestRate())
+                .paymentStatus("N")
+                .tradeNumber(tradeNumber)
+                .branchId(businessDateAndBranchId.getBranchId())
+                .registrantId(loginMemberId)
+                .creationDate(businessDateAndBranchId.getBusinessDate())
+                .version(1L)
+                .build();
     }
+
+
 }

--- a/src/main/java/com/kcc/banking/domain/interest/mapper/InterestMapper.java
+++ b/src/main/java/com/kcc/banking/domain/interest/mapper/InterestMapper.java
@@ -1,17 +1,17 @@
 package com.kcc.banking.domain.interest.mapper;
 
 import com.kcc.banking.domain.employee.dto.request.BusinessDateAndBranchId;
-import com.kcc.banking.domain.interest.dto.request.AccountIdWithExpireDate;
-import com.kcc.banking.domain.interest.dto.request.PaymentStatusRollback;
-import com.kcc.banking.domain.interest.dto.request.PaymentStatusUpdate;
+import com.kcc.banking.domain.interest.dto.request.*;
 import com.kcc.banking.domain.interest.dto.response.InterestSum;
-import com.kcc.banking.domain.interest.dto.request.InterestCreate;
 import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface InterestMapper {
 
+    // 일별 이자 생성
     void createInterest(InterestCreate interestCreate);
+    // 월별 이자 생성
+    void createInterestSaving(SavingInterestCreate savingInterestCreate);
 
     // 세전 이자액 합계(해지 시 사용)
     InterestSum findInterestSum(String accountId);
@@ -27,4 +27,6 @@ public interface InterestMapper {
 
     // 영업일 되돌리기에 의한 이자 삭제
     void deleteInterest(BusinessDateAndBranchId businessDateAndBranchId);
+
+
 }

--- a/src/main/java/com/kcc/banking/domain/interest/service/InterestService.java
+++ b/src/main/java/com/kcc/banking/domain/interest/service/InterestService.java
@@ -4,18 +4,19 @@ import com.kcc.banking.common.util.AuthenticationUtils;
 import com.kcc.banking.domain.account.dto.request.StatusWithTrade;
 import com.kcc.banking.domain.account.dto.response.AccountDetailForInterest;
 import com.kcc.banking.domain.account.service.AccountService;
+import com.kcc.banking.domain.business_day_close.dto.request.BusinessDateAndEmployeeId;
 import com.kcc.banking.domain.common.dto.request.CurrentData;
-import com.kcc.banking.domain.interest.dto.request.AccountIdWithExpireDate;
-import com.kcc.banking.domain.interest.dto.request.PaymentStatusRollback;
-import com.kcc.banking.domain.interest.dto.request.PaymentStatusUpdate;
+import com.kcc.banking.domain.common.service.CommonService;
+import com.kcc.banking.domain.interest.dto.request.*;
 import com.kcc.banking.domain.interest.dto.response.InterestSum;
 import com.kcc.banking.domain.employee.dto.request.BusinessDateAndBranchId;
-import com.kcc.banking.domain.interest.dto.request.InterestCreate;
 import com.kcc.banking.domain.interest.mapper.InterestMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,16 +26,37 @@ public class InterestService {
 
     private final InterestMapper interestMapper;
     private final AccountService accountService;
+    private final CommonService commonService;
 
+    /**
+     * @Discription
+     * 1. 지점 마감 tradeNumber와 동일한 이자 내역 생성
+     * 2. 보통예금 / 자율적금 분기처리
+     * 2-1. 보통에금 - 매일 일자별 이자 생성
+     * 3. 매월 1일인지 영업일 확인
+     * 4. 자율적금 단리 / 복리 분기
+     * 4-1. 자율적금 단리 계산
+     * 4-2. 자율적금 복리 계산
+     * @param tradeNumber
+     * @param businessDateAndBranchId
+     */
     public void createInterest(String tradeNumber, BusinessDateAndBranchId businessDateAndBranchId){
-        String branchId = businessDateAndBranchId.getBranchId();
-        Long loginMemberId = AuthenticationUtils.getLoginMemberId();
-
-
-        List<AccountDetailForInterest> accountList = accountService.getAccountListByBranchId(Long.parseLong(branchId));
-        List<InterestCreate> interestCreateList = accountList.stream().map(account -> InterestCreate.of(account, loginMemberId, businessDateAndBranchId, tradeNumber)).toList();
-
+        CurrentData currentData = commonService.getCurrentData();
+        // 지점 번호로 등록된 계좌 목록 불러오기
+        List<AccountDetailForInterest> accountList = accountService.getAccountListByBranchId(currentData.getBranchId());
+        // 새로운 이자 내역 생성
+        // 2-1. 보통예금의 경우 ( 단리 )
+        // period로 구분
+        List<InterestCreate> interestCreateList = accountList.stream().filter(account -> account.getPeriod().equals("00")).map(account -> InterestCreate.of(account, currentData.getEmployeeId(), businessDateAndBranchId, tradeNumber)).toList();
+        // 이자 생성
         interestCreateList.forEach(interestMapper::createInterest);
+        // 4. 매월 1일인지 영업일 확인
+        LocalDate date = LocalDate.parse(businessDateAndBranchId.getBusinessDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        // 매월 1일이라면
+        if (date.getDayOfMonth() == 1) {
+            // 자율적금
+            //List<SavingInterestCreate> intersetSavingCreateList = accountList.stream().filter(account -> account.getProductType().equals("FLEXIBLE")).map(account -> SavingInterestCreate.of(account, currentData.getEmployeeId(), businessDateAndBranchId, tradeNumber)).toList();
+        }
     }
 
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -268,11 +268,69 @@ INSERT INTO Product (id, branch_id, name, interest_rate, effective_date, period,
                      product_type)
 VALUES (product_seq.NEXTVAL, 1, '3년만기정기적금', 3.5, SYSDATE, '36', 0.15, 1, 'PRIVATE', 'FIXED');
 
+-- 자율적금 단리
+-- 12
 INSERT INTO Product (id, branch_id, name, interest_rate, effective_date, period, tax_rate, registrant_id, account_type,
-                     product_type)
-VALUES (product_seq.NEXTVAL, 1, '1년만기자유적금', 3.5, TO_TIMESTAMP('2024-02-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), '12',
-        0.15, 1, 'PRIVATE', 'FLEXIBLE');
+                     product_type, interest_calculation_method)
+VALUES (product_seq.NEXTVAL, 1, '네오자유행복적금', 2.5, SYSDATE, '12',
+        0.15, 1, 'PRIVATE', 'FLEXIBLE', 'SIMPLE');
+--13
+INSERT INTO Product (id, branch_id, name, interest_rate, effective_date, period, tax_rate, registrant_id, account_type,
+                     product_type, interest_calculation_method)
+VALUES (product_seq.NEXTVAL, 1, '네오자유청년행복적금', 3.5, SYSDATE, '12',
+        0.15, 1, 'PRIVATE', 'FLEXIBLE', 'SIMPLE');
 
+
+-- 자율적금 복리
+--14
+INSERT INTO Product (id, branch_id, name, interest_rate, effective_date, period, tax_rate, registrant_id, account_type,
+                     product_type, interest_calculation_method)
+VALUES (product_seq.NEXTVAL, 1, '다달이더하는자유적금', 0.4, SYSDATE, '12',
+        0.15, 1, 'PRIVATE', 'FLEXIBLE', 'COMPOUND');
+--15
+INSERT INTO Product (id, branch_id, name, interest_rate, effective_date, period, tax_rate, registrant_id, account_type,
+                     product_type, interest_calculation_method)
+VALUES (product_seq.NEXTVAL, 1, '다달이행복청년자유적금', 0.6, SYSDATE, '12',
+        0.15, 1, 'PRIVATE', 'FLEXIBLE', 'COMPOUND');
+
+---------- 단리 자율 적금 생성 ----------
+-- 12번 상품
+INSERT INTO Account(id, branch_id, customer_id, product_id, registrant_id, start_date, preferential_interest_rate,
+                    expire_date, password, balance, account_type, open_date, status,
+                    version)
+VALUES ('001-0000071-7171', 1, 2, 12, 2, TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+        0.1, TO_TIMESTAMP('2025-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+        '$2a$12$KEC0twTfMAlrbchL4p4lPOyX7/n0Q/eNZjsLkA0yY5j.udeV6MiO6',
+        100000, 'PRIVATE', TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 'OPN', 1);
+
+-- 13번 상품
+INSERT INTO Account(id, branch_id, customer_id, product_id, registrant_id, start_date, preferential_interest_rate,
+                        expire_date, password, balance, account_type, open_date, status,
+                        version)
+VALUES ('001-0000072-7272', 1, 2, 13, 2, TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    0.1, TO_TIMESTAMP('2025-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    '$2a$12$KEC0twTfMAlrbchL4p4lPOyX7/n0Q/eNZjsLkA0yY5j.udeV6MiO6',
+    120000, 'PRIVATE', TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 'OPN', 1);
+
+
+---------- 복리 자율 적금 생성 ----------
+--14번 상품
+INSERT INTO Account(id, branch_id, customer_id, product_id, registrant_id, start_date, preferential_interest_rate,
+                    expire_date, password, balance, account_type, open_date, status,
+                    version)
+VALUES ('001-0000073-7373', 1, 2, 14, 2, TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    0.1, TO_TIMESTAMP('2025-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    '$2a$12$KEC0twTfMAlrbchL4p4lPOyX7/n0Q/eNZjsLkA0yY5j.udeV6MiO6',
+    120000, 'PRIVATE', TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 'OPN', 1);
+
+--15번 상품
+INSERT INTO Account(id, branch_id, customer_id, product_id, registrant_id, start_date, preferential_interest_rate,
+                    expire_date, password, balance, account_type, open_date, status,
+                    version)
+VALUES ('001-0000074-7474', 1, 2, 14, 2, TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    0.1, TO_TIMESTAMP('2025-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'),
+    '$2a$12$KEC0twTfMAlrbchL4p4lPOyX7/n0Q/eNZjsLkA0yY5j.udeV6MiO6',
+    140000, 'PRIVATE', TO_TIMESTAMP('2024-08-01 00:00:00', 'YYYY-MM-DD HH24:MI:SS'), 'OPN', 1);
 
 ---------- 계좌 생성 ----------
 -- 지점

--- a/src/main/resources/mapper/accountMapper.xml
+++ b/src/main/resources/mapper/accountMapper.xml
@@ -249,7 +249,11 @@
         ac.registrant_id,
         ac.preferential_interest_rate as preferential_interest_rate,
         p.interest_rate as interest_rate,
-        ac.balance
+        ac.balance,
+        p.account_type,
+        p.product_type,
+        p.interest_calculation_method,
+        p.period
         FROM account ac
         JOIN product p ON ac.product_id = p.id
         WHERE ac.branch_id = #{branchId}

--- a/src/main/resources/mapper/interestMapper.xml
+++ b/src/main/resources/mapper/interestMapper.xml
@@ -7,19 +7,21 @@
 
     <!--  세전 이자액 합계(해지 시 사용)  -->
     <select id="findInterestSum" parameterType="java.lang.String">
-        SELECT acc_id AS account_id,
-        sum(amount) AS amount_sum
+        SELECT acc_id      AS account_id,
+               sum(amount) AS amount_sum
         FROM Interest
-        WHERE acc_id = #{accountId} AND payment_status = 'N'
+        WHERE acc_id = #{accountId}
+          AND payment_status = 'N'
         GROUP BY acc_id
     </select>
 
     <!--  세전 이자액 합계(해지 취소 시 사용)  -->
     <select id="findPreTaxInterestSum" parameterType="AccountIdWithExpireDate">
-        SELECT acc_id AS account_id,
-        sum(amount) AS amount_sum
+        SELECT acc_id      AS account_id,
+               sum(amount) AS amount_sum
         FROM Interest
-        WHERE acc_id = #{accountId} AND payment_date = #{expireDate}
+        WHERE acc_id = #{accountId}
+          AND payment_date = #{expireDate}
         GROUP BY acc_id
     </select>
 
@@ -29,7 +31,7 @@
             SELECT employee_seq.nextval FROM dual
         </selectKey>
         INSERT INTO Employee (id, branch_id, name, phone_number, email,birth_date, password, roles)
-        VALUES (#{id}, #{branchId}, #{name},  #{phoneNumber}, #{email},#{birthDate}, #{password}, #{roles})
+        VALUES (#{id}, #{branchId}, #{name}, #{phoneNumber}, #{email},#{birthDate}, #{password}, #{roles})
     </insert>
 
     <insert id="createInterest" parameterType="InterestCreate">
@@ -40,67 +42,101 @@
 
         INSERT INTO interest
         (
-            id,
-            acc_id,
-            branch_id,
-            amount,
-            interest_rate,
-            payment_status,
-            trade_number,
-            creation_date,
-            registrant_id,
-            registration_date,
-            version
+        id,
+        acc_id,
+        branch_id,
+        amount,
+        interest_rate,
+        preferential_interest_rate,
+        payment_status,
+        trade_number,
+        creation_date,
+        registrant_id,
+        registration_date,
+        version
         ) VALUES
         (
-            #{id},
-            #{accId, jdbcType=VARCHAR},
-            #{branchId, jdbcType=BIGINT},
-            #{amount, jdbcType=DECIMAL},
-            #{interestRate, jdbcType=FLOAT},
-            #{paymentStatus, jdbcType=VARCHAR},
-            #{tradeNumber, jdbcType=BIGINT},
-            #{creationDate},
-            #{registrantId, jdbcType=BIGINT},
-            SYSTIMESTAMP,
-            #{version}
+        #{id},
+        #{accId, jdbcType=VARCHAR},
+        #{branchId, jdbcType=BIGINT},
+        #{amount, jdbcType=DECIMAL},
+        #{interestRate, jdbcType=FLOAT},
+        #{preferentialInterestRate, jdbcType=FLOAT},
+        #{paymentStatus, jdbcType=VARCHAR},
+        #{tradeNumber, jdbcType=BIGINT},
+        #{creationDate},
+        #{registrantId, jdbcType=BIGINT},
+        SYSTIMESTAMP,
+        #{version}
+        )
+    </insert>
+
+    <insert id="createInterestSaving" parameterType="savingInterestCreate">
+        <selectKey keyProperty="id" resultType="java.lang.Long" order="BEFORE">
+            SELECT interest_seq.nextval FROM dual
+        </selectKey>
+
+        INSERT INTO interest
+        (
+        id,
+        acc_id,
+        branch_id,
+        amount,
+        interest_rate,
+        preferential_interest_rate,
+        payment_status,
+        trade_number,
+        creation_date,
+        registrant_id,
+        registration_date,
+        version
+        ) VALUES
+        (
+        #{id},
+        #{accId, jdbcType=VARCHAR},
+        #{branchId, jdbcType=BIGINT},
+        #{amount, jdbcType=DECIMAL},
+        #{interestRate, jdbcType=FLOAT},
+        #{preferentialInterestRate, jdbcType=FLOAT},
+        #{paymentStatus, jdbcType=VARCHAR},
+        #{tradeNumber, jdbcType=BIGINT},
+        #{creationDate},
+        #{registrantId, jdbcType=BIGINT},
+        SYSTIMESTAMP,
+        #{version}
         )
     </insert>
 
     <!--    해지에 의한 이자 테이블 상태 및 지급일 변경  -->
     <update id="updateByClose" parameterType="PaymentStatusUpdate">
         UPDATE INTEREST
-        SET
-        payment_date = #{payDate},
-        payment_status = 'Y',
-        branch_id = #{branchId},
-        modifier_date = SYSDATE,
-        modifier_id = #{modifierId},
-        version = version + 1
-        WHERE
-        acc_id = #{accId}
-        AND
-        payment_status = 'N'
+        SET payment_date   = #{payDate},
+            payment_status = 'Y',
+            branch_id      = #{branchId},
+            modifier_date  = SYSDATE,
+            modifier_id    = #{modifierId},
+            version        = version + 1
+        WHERE acc_id = #{accId}
+          AND payment_status = 'N'
     </update>
 
     <!--    해지 취소에 의한 이자 테이블 상태 및 지급일 변경-->
     <update id="updateByCloseCancel" parameterType="PaymentStatusRollback">
         UPDATE INTEREST
-        SET
-        payment_date = NULL,
-        payment_status = 'N',
-        branch_id = #{branchId},
-        modifier_date = SYSDATE,
-        modifier_id = #{modifierId},
-        version = version + 1
-        WHERE
-        acc_id = #{accId}
-        AND
-        payment_date = #{expireDate}
+        SET payment_date   = NULL,
+            payment_status = 'N',
+            branch_id      = #{branchId},
+            modifier_date  = SYSDATE,
+            modifier_id    = #{modifierId},
+            version        = version + 1
+        WHERE acc_id = #{accId}
+          AND payment_date = #{expireDate}
     </update>
 
     <delete id="deleteInterest" parameterType="BusinessDateAndBranchId">
-        delete from interest
-        where branch_id = #{branchId} and creation_date = #{businessDate}
+        delete
+        from interest
+        where branch_id = #{branchId}
+          and creation_date = #{businessDate}
     </delete>
 </mapper>

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -156,6 +156,7 @@ CREATE TABLE Interest (
                           creation_date TIMESTAMP NULL,
                           amount DECIMAL NULL,
                           interest_rate NUMBER NULL,
+                          preferential_interest_rate NUMBER NULL,
                           payment_status VARCHAR(1) NULL,
                           trade_number NUMBER NULL,
                           registration_date TIMESTAMP NULL,

--- a/src/main/webapp/resources/js/page/account-close.js
+++ b/src/main/webapp/resources/js/page/account-close.js
@@ -38,14 +38,12 @@ function getAccountDetail() {
                     return;
                 }else{
                     accountData = data;
-                    console.log(data)
 
                     const textAfterInter = Number(data.amountSum) * (1-Number(data.productTaxRate));
                     const totalPayment = data.accountBal + textAfterInter;
                     accountData.textAfterInter = textAfterInter;
                     accountData.totalPayment = totalPayment;
-                    console.log("=========================accountDataTotalPaymemt");
-                    console.log(accountData.totalPayment, "==============총 지급 금액")
+
                     console.log(data.accountId);
                     $('#table-content tbody').append(
                         '<tr>' +


### PR DESCRIPTION
## 💡 관련 이슈
#337 

> 매니저 마감 수정: 자유적금 단리/복리 이자 계산

## ✅ 작업 상세 내용

- [x] 자유적금 단리/복리 이자 계산

## ⭐ 특이사항
- 현재 매월 1일인지 판별하는 코드 주석처리 - 매일 단리/복리로 쌓이고 있음

## 📃 참고할만한 자료
